### PR TITLE
Fix some denials on Ubuntu 14.04 with 0.9.17.1

### DIFF
--- a/opt.spotify.spotify-client.spotify
+++ b/opt.spotify.spotify-client.spotify
@@ -25,6 +25,8 @@
   owner @{HOME}/.cache/spotify/** rwk,
   owner @{HOME}/.local/share/spotify/ rw,
   owner @{HOME}/.local/share/spotify/** rwk,
+  owner @{HOME}/.local/share/fonts/ r,
+  owner @{HOME}/.local/share/fonts/* r,
  
   # Application and libraries
   /opt/spotify/spotify-client/** mr,
@@ -38,6 +40,8 @@
   owner /run/user/*/dconf/user rw,
 
   # Gnome
+  owner @{HOME}/.gtkrc-2.0 r,
+  owner @{HOME}/.gtkrc-2.0-gnome-color-chooser r,
   owner @{HOME}/.config/gtk-2.0/gtkfilechooser.ini r,
 
   # QT


### PR DESCRIPTION
To use this profile with the LTS, I had to comment the ICE-unix socket as
the unix directive is not supported with the shipped apparmor version.
